### PR TITLE
fixed coverage script to match google code style guide.

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -1,41 +1,41 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -e
 
 workdir=.cover
-profile="$workdir/cover.out"
+profile="${workdir}/cover.out"
 mode=count
 
 generate_cover_data() {
-		rm -rf "$workdir"
-		mkdir "$workdir"
+  rm -rf "${workdir}"
+  mkdir "${workdir}"
 
-		for pkg in "$@"; do
-				f="$workdir/$(echo $pkg | tr / -).cover"
-				go test -covermode="$mode" -coverprofile="$f" "$pkg"
-		done
+  for pkg in "$@"; do
+    f="${workdir}/$(echo ${pkg} | tr / -).cover"
+    go test -covermode="${mode}" -coverprofile="${f}" "${pkg}"
+  done
 
-		echo "mode: $mode" >"$profile"
-		grep -h -v "^mode:" "$workdir"/*.cover >>"$profile"
+  echo "mode: ${mode}" >"${profile}"
+  grep -h -v "^mode:" "${workdir}"/*.cover >>"${profile}"
 }
 
 show_cover_report() {
-		go tool cover -${1}="$profile"
+  go tool cover -${1}="${profile}"
 }
 
 push_to_coveralls() {
-		goveralls -coverprofile="$profile"
+  goveralls -coverprofile="${profile}"
 }
 
 generate_cover_data $(go list ./...)
 show_cover_report func
 push_to_coveralls
-case "$1" in
-"")
-		;;
---coveralls)
-		push_to_coveralls ;;
-*)
-		echo >&2 "error: invalid option: $1" ;;
+case "${1}" in
+  "")
+    ;;
+  --coveralls)
+    push_to_coveralls ;;
+  *)
+    echo >&2 "error: invalid option: ${1}" ;;
 esac
-rm -rf "$workdir"
+rm -rf "${workdir}"


### PR DESCRIPTION
- fixed shebang (sticy /bin/bash)
- fixed indentation (tabs replaced with spaces)
- fixed variable expansion